### PR TITLE
Add chart for mercury server with db

### DIFF
--- a/charts/chainlink/templates/chainlink-cm.yaml
+++ b/charts/chainlink/templates/chainlink-cm.yaml
@@ -28,3 +28,5 @@ data:
     HTTPSPort = 0
   overrides.toml: |
 {{ indent 4 .Values.toml }}
+  secrets.toml: |
+{{ indent 4 .Values.secretsToml }}

--- a/charts/chainlink/templates/chainlink-deployment.yaml
+++ b/charts/chainlink/templates/chainlink-deployment.yaml
@@ -104,7 +104,7 @@ spec:
         - name: node
           image: {{ .Values.chainlink.image.image }}:{{ .Values.chainlink.image.version }}
           imagePullPolicy: Always
-          command: ["bash", "-c", "while ! pg_isready --host 0.0.0.0 --port 5432; do echo \"waiting for database to start\"; sleep 1; done && chainlink -c /etc/node-secrets-volume/default.toml -c /etc/node-secrets-volume/overrides.toml node start -d -p /etc/node-secrets-volume/node-password -a /etc/node-secrets-volume/apicredentials --vrfpassword=/etc/node-secrets-volume/apicredentials"]
+          command: ["bash", "-c", "while ! pg_isready --host 0.0.0.0 --port 5432; do echo \"waiting for database to start\"; sleep 1; done && chainlink -c /etc/node-secrets-volume/default.toml -c /etc/node-secrets-volume/overrides.toml -secrets /etc/node-secrets-volume/secrets.toml node start -d -p /etc/node-secrets-volume/node-password -a /etc/node-secrets-volume/apicredentials --vrfpassword=/etc/node-secrets-volume/apicredentials"]
           ports:
             - name: access
               containerPort: {{ .Values.chainlink.web_port }}

--- a/charts/chainlink/values.yaml
+++ b/charts/chainlink/values.yaml
@@ -25,6 +25,7 @@ replicas: 1
 prometheus: false
 
 toml: ''
+secretsToml: ''
 
 env:
   CL_DEV: 'false'

--- a/charts/mercury-server/.helmignore
+++ b/charts/mercury-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mercury-server/Chart.yaml
+++ b/charts/mercury-server/Chart.yaml
@@ -1,14 +1,24 @@
-apiVersion: v1
-name: chainlink
+apiVersion: v2
+name: mercury-server
 description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: '1.9.0'
+appVersion: 'sha-08ffa1d'

--- a/charts/mercury-server/templates/NOTES.txt
+++ b/charts/mercury-server/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mercury-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mercury-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mercury-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mercury-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/mercury-server/templates/_helpers.tpl
+++ b/charts/mercury-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mercury-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mercury-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mercury-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mercury-server.labels" -}}
+helm.sh/chart: {{ include "mercury-server.chart" . }}
+{{ include "mercury-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mercury-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mercury-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mercury-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mercury-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mercury-server/templates/_ingress.yaml
+++ b/charts/mercury-server/templates/_ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mercury-server.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mercury-server/templates/configmap-env.yaml
+++ b/charts/mercury-server/templates/configmap-env.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mercury-server.fullname" . }}
+  labels: {{- include "mercury-server.labels" . | nindent 4 }}
+data: {{ toYaml .Values.envVars | nindent 2 }}

--- a/charts/mercury-server/templates/deployment.yaml
+++ b/charts/mercury-server/templates/deployment.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "mercury-server.fullname" . }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  serviceName: {{ include "mercury-server.fullname" . }}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.db.capacity }}  
+  selector:
+    matchLabels:
+      {{- include "mercury-server.selectorLabels" . | nindent 6 }}
+      app: {{ include "mercury-server.fullname" . }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mercury-server.selectorLabels" . | nindent 8 }}
+        app: {{ include "mercury-server.fullname" . }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mercury-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: mercury-db-config-map
+          configMap:
+            name: mercury-db-cm
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.imageRepo }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagPullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.envVars.PORT }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "mercury-server.fullname" . }}
+            - secretRef:
+                name: {{ include "mercury-server.fullname" . }}
+        - name: mercury-db
+          image: postgres:11.15
+          command:
+            - docker-entrypoint.sh
+          args:
+            - "-c"
+            - "shared_preload_libraries=pg_stat_statements"
+            - "-c"
+            - "pg_stat_statements.track=all"
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: mercury
+            - name: POSTGRES_PASSWORD
+              value: verylongdatabasepassword
+            - name: PGPASSWORD
+              value: verylongdatabasepassword
+            - name: PGUSER
+              value: postgres
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          startupProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            failureThreshold: 20
+          resources:
+            requests:
+              memory: {{ .Values.db.resources.requests.memory }}
+              cpu: {{ .Values.db.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.db.resources.limits.memory }}
+              cpu: {{ .Values.db.resources.limits.cpu }}
+          volumeMounts:
+            - mountPath: /docker-entrypoint-initdb.d/init.sql
+              name: mercury-db-config-map
+              subPath: init.sql
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/mercury-server/templates/hpa.yaml
+++ b/charts/mercury-server/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mercury-server.fullname" . }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mercury-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/mercury-server/templates/ingress.yaml
+++ b/charts/mercury-server/templates/ingress.yaml
@@ -1,0 +1,74 @@
+{{- $fullName := include "mercury-server.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- if .Values.ingress.private.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-private" $fullName }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+    mode: private
+  {{- with .Values.ingress.private.annotations }}
+  annotations:
+    alb.ingress.kubernetes.io/actions.default-rule: >-
+      {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"403","messageBody":"Forbidden"}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.private.className }}
+  defaultBackend:
+    service:
+      name: default-rule
+      port:
+        name: use-annotation
+  rules:
+  - host: "{{ .Values.ingress.private.domain }}"
+    http:
+      paths:
+      {{- range $path := .Values.ingress.private.allowedPaths }}
+      - path: {{ $path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $servicePort }}
+      {{- end }}
+{{- end }}
+{{- if .Values.ingress.public.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-public" $fullName }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+    mode: public
+  {{- with .Values.ingress.public.annotations }}
+  annotations:
+    alb.ingress.kubernetes.io/actions.default-rule: >-
+      {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"403","messageBody":"Forbidden"}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.public.className }}
+  defaultBackend:
+    service:
+      name: default-rule
+      port:
+        name: use-annotation
+  rules:
+  - host: "{{ .Values.ingress.public.domain }}"
+    http:
+      paths:
+      {{- range $path := .Values.ingress.public.allowedPaths }}
+      - path: {{ $path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $servicePort }}
+      {{- end }}
+{{- end }}

--- a/charts/mercury-server/templates/mercury-db-cm.yaml
+++ b/charts/mercury-server/templates/mercury-db-cm.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: mercury-db-cm
+    release: mercury-db
+  name: mercury-db-cm
+data:
+  init.sql: |-
+    CREATE EXTENSION pg_stat_statements;
+    CREATE TABLE IF NOT EXISTS reports  (
+      id serial NOT NULL PRIMARY KEY,
+      feed_id bytea NOT NULL,
+      price numeric(58,0) NOT NULL,
+      full_report bytea NOT NULL,
+      blob bytea NOT NULL,
+      block_number bigint NOT NULL,
+      config_digest bytea NOT NULL,
+      epoch numeric(32) NOT NULL,
+      round int8 NOT NULL,
+      observations_timestamp bigint NOT NULL,
+      transmitting_operator bytea NOT NULL,
+      created_at timestamptz NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_reports_feed_id_block_number ON reports (feed_id, block_number, created_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_block_number_config_digest_epoch_round ON reports (block_number, config_digest, epoch, round);

--- a/charts/mercury-server/templates/secret.yaml
+++ b/charts/mercury-server/templates/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mercury-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+stringData: {{ toYaml .Values.envSecrets | nindent 2 }}

--- a/charts/mercury-server/templates/service.yaml
+++ b/charts/mercury-server/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mercury-server.fullname" . }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mercury-server.selectorLabels" . | nindent 4 }}
+    app: {{ include "mercury-server.fullname" . }}

--- a/charts/mercury-server/templates/serviceaccount.yaml
+++ b/charts/mercury-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mercury-server.serviceAccountName" . }}
+  labels:
+    {{- include "mercury-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mercury-server/values.yaml
+++ b/charts/mercury-server/values.yaml
@@ -1,0 +1,104 @@
+# Default values for mercury-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+imageRepo: 795953128386.dkr.ecr.us-west-2.amazonaws.com/mercury-server
+imageTag: latest
+imagePullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+envVars:
+  PORT: '3000'
+  DATABASE_URL: 'postgresql://postgres:verylongdatabasepassword@localhost:5432/mercury?sslmode=disable'
+  AUTH_CLIENT_USER: client
+  AUTH_CLIENT_PASSWORD: clientpass
+  AUTH_NODE_USER: node
+  AUTH_NODE_PASSWORD: nodepass
+envSecrets: {}
+
+db:
+  stateful: true
+  capacity: 5Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 3000
+
+ingress:
+  enabled: false
+  private:
+    enabled: true
+    domain: put.domain.here
+    className: alb
+    allowedPaths:
+      - /metrics
+    annotations:
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+  public:
+    enabled: true
+    domain: put.domain.here
+    className: alb
+    allowedPaths:
+      - /client
+    annotations:
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+
+resources:
+  # todo: adjust later
+  limits:
+    cpu: 1000m
+    memory: 1024Mi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Envs needed to run mercury_test.go in sdlc k8:

```
MERCURY_SERVER_IMAGE="795953128386.dkr.ecr.us-west-2.amazonaws.com/mercury-server"
MERCURY_SERVER_TAG="sha-08ffa1d"
```