### PR TITLE
set the stateful db default volume to 1gb

### DIFF
--- a/charts/chainlink/values.yaml
+++ b/charts/chainlink/values.yaml
@@ -13,7 +13,7 @@ chainlink:
       memory: 1024Mi
 db:
   stateful: true
-  capacity: 5Gi
+  capacity: 1Gi
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
We only use on average about 90Mb of the volume every 10 days so this leaves plenty of room for expansion and for 30 day runs. This data was found by looking at several currently running 4 day and 8 day runs and extrapolating the data out.